### PR TITLE
Nginx upgrade due to out of bounds read

### DIFF
--- a/nginx-service/Dockerfile
+++ b/nginx-service/Dockerfile
@@ -1,4 +1,4 @@
 FROM nginx:1.22.0
 ADD conf.d /etc/nginx/conf.d
 # sid (unstable) (libs): New Perl Compatible Regular Expression Library- 8 bit runtime files
-RUN apk add --no-cache pcre2=10.40
+RUN apt-get update && apt-get install -y pcre2=10.40

--- a/nginx-service/Dockerfile
+++ b/nginx-service/Dockerfile
@@ -1,4 +1,4 @@
 FROM nginx:1.22.0
 ADD conf.d /etc/nginx/conf.d
 # sid (unstable) (libs): New Perl Compatible Regular Expression Library- 8 bit runtime files
-RUN apt-get update && apt-get install -y libpcre2-8-0=10.40-1:amd64
+RUN apt-get update

--- a/nginx-service/Dockerfile
+++ b/nginx-service/Dockerfile
@@ -1,4 +1,4 @@
 FROM nginx:1.22.0
 ADD conf.d /etc/nginx/conf.d
 # sid (unstable) (libs): New Perl Compatible Regular Expression Library- 8 bit runtime files
-RUN apt-get update && apt-get install -y libpcre2-8-0=10.40-1
+RUN apt-get update && apt-get install -y libpcre2-8-0=10.40-1:amd64

--- a/nginx-service/Dockerfile
+++ b/nginx-service/Dockerfile
@@ -1,4 +1,4 @@
 FROM nginx:1.22.0
 ADD conf.d /etc/nginx/conf.d
 # sid (unstable) (libs): New Perl Compatible Regular Expression Library- 8 bit runtime files
-RUN apt-get update && apt-get install -y libpcre2-8-0
+RUN apt-get update && apt-get install -y libpcre2-8-0=10.40-1

--- a/nginx-service/Dockerfile
+++ b/nginx-service/Dockerfile
@@ -1,4 +1,4 @@
 FROM nginx:1.22.0
 ADD conf.d /etc/nginx/conf.d
 # sid (unstable) (libs): New Perl Compatible Regular Expression Library- 8 bit runtime files
-RUN apt-get update && apt-get install -y libpcre2-8-0@10.40-1
+RUN apt-get update && apt-get install -y libpcre2-8-0

--- a/nginx-service/Dockerfile
+++ b/nginx-service/Dockerfile
@@ -1,4 +1,4 @@
 FROM nginx:1.22.0
 ADD conf.d /etc/nginx/conf.d
 # sid (unstable) (libs): New Perl Compatible Regular Expression Library- 8 bit runtime files
-RUN apt-get update && apt-get install -y pcre2=10.40
+RUN apt-get update && apt-get install -y libpcre2-8-0@10.40-1

--- a/nginx-service/Dockerfile
+++ b/nginx-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.22.0
+FROM nginx:1.22-alpine
 ADD conf.d /etc/nginx/conf.d
 # sid (unstable) (libs): New Perl Compatible Regular Expression Library- 8 bit runtime files
-RUN apt-get update
+RUN apk add --no-cache pcre2=10.39-r0


### PR DESCRIPTION
Vulnerable module: pcre2/libpcre2-8-0@10.36-2  
Switched to FROM nginx:1.22-alpine 
Temporary Fix :  replaced by pcre2=10.39-r0